### PR TITLE
Fix: Corrected variable in h100 example tfvars file

### DIFF
--- a/examples/h100-80gb-sxm-ib.tfvars
+++ b/examples/h100-80gb-sxm-ib.tfvars
@@ -6,7 +6,7 @@ vpc_subnet_id = "80cf6356-da22-42c8-8925-d5fb1e3e55ad"
 
 # slurm-compute-node configuration
 slurm_compute_node_type = "h100-80gb-sxm-ib.8x"
-slurm_compute_node_ib_network_id = "474dbfe2-ffb3-44ce-87a4-cea659fddea3"
+slurm_compute_node_ib_partition_id = "474dbfe2-ffb3-44ce-87a4-cea659fddea3"
 slurm_compute_node_count = 4
 
 # slurm users configuration


### PR DESCRIPTION
examples/h100-80gb-sxm-ib.tfvars has a `slurm_compute_node_ib_network_id` variable which needs to be substituted with `slurm_compute_node_ib_partition_id`

Otherwise, the following error is encountered when creating a Slurm cluster:

`│ Error: Failed to create instance
│
│   with crusoe_compute_instance.slurm_compute_node[0],
│   on main.tf line 94, in resource "crusoe_compute_instance" "slurm_compute_node":
│   94: resource "crusoe_compute_instance" "slurm_compute_node" {
│
│ There was an error starting a create instance operation: bad request, check request parameters: infiniband partition ID is required for this VM type`