### PR TITLE
fix: Ansible logic to determine which nodes need NVIDIA monitoring co…

### DIFF
--- a/ansible/roles/observability/tasks/main.yml
+++ b/ansible/roles/observability/tasks/main.yml
@@ -118,7 +118,7 @@
   when: 
     - inventory_hostname in groups['slurm_compute_nodes']
     - instance_type is defined
-    - instance_type.split('.')[0] | regex_search(gpu_instance_types | join('|'))
+    - (gpu_instance_types | join('|')) is search(instance_type.split('.')[0])
   block:
     - name: Install Docker and dependencies
       apt:


### PR DESCRIPTION
The Ansible regex_search function returns a string when there is a match, whereas the condition logic requires a Boolean value, so this step would fail when encountering a gpu host type. The fix just replaces regex_search with the 'is search' construct to return True if the host type is in the list of gpu host types.