### PR TITLE
fix: prevent slurm gpu compute nodes showing inval by linking nvml library

### DIFF
--- a/ansible/roles/slurm_compute_node/tasks/main.yaml
+++ b/ansible/roles/slurm_compute_node/tasks/main.yaml
@@ -30,6 +30,12 @@
     group: root
     mode: '0755'
 
+- name: Create symbolic link for NVML library
+  ansible.builtin.file:
+    src: /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1
+    dest: /usr/lib/x86_64-linux-gnu/libnvidia-ml.so
+    state: link
+
 - name: Restart slurmd
   ansible.builtin.systemd_service:
     name: slurmd

--- a/main.tf
+++ b/main.tf
@@ -220,3 +220,18 @@ resource "null_resource" "ansible_playbook" {
     ansible_group.all
   ]
 }
+
+output "slurm_head_nodes_addr" {
+  description = "Head node(s)"
+  value = crusoe_compute_instance.slurm_head_node[*].network_interfaces[0].public_ipv4.address
+}
+
+output "slurm_login_nodes_addr" {
+  description = "Login node(s)"
+  value = crusoe_compute_instance.slurm_login_node[*].network_interfaces[0].public_ipv4.address
+}
+
+output "slurm_compute_nodes_addr" {
+  description = "Compute node(s)"
+  value = crusoe_compute_instance.slurm_compute_node[*].network_interfaces[0].public_ipv4.address
+}


### PR DESCRIPTION
Previously, gpu compute nodes would show up as 'inval' state because the nvml library needed by slurmd was not available as the expected filename. The problem is addressed along the same lines as explained here = https://support.crusoecloud.com/hc/en-us/articles/32357411759899-Nvidia-Driver-Upgrade-Causing-Invalid-Slurm-Compute-Nodes.

Additionally, this PR adds some terraform outputs to make it easier to see the public IPs of the Slurm nodes.