### PR TITLE
feat: enable https (self signed cert) for Grafana UI

### DIFF
--- a/ansible/roles/observability/templates/grafana.ini.j2
+++ b/ansible/roles/observability/templates/grafana.ini.j2
@@ -1,6 +1,7 @@
 [server]
 http_addr = 0.0.0.0
 http_port = 3000
+protocol = https
 
 [security]
 admin_user = admin


### PR DESCRIPTION
Enables https for Grafana UI. We don't provide any cert or key details so Grafana creates them whenever it starts up. Although it's not a real certificate and will trigger a browser warning, it's a bit more palatable to our customers than serving it over plain http. I updated the KB article to link to the Grafana instructions on how to add a 'real' cert and key.