### PR TITLE
Adding Options for Custom Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ slurm_shared_volumes = [{
 }]
 ```
 
+## Using Custom Images
+By default, all slurm nodes in the solution uses `ubuntu22.04-nvidia-slurm:latest`, which is a slurm VM image provided by Crusoe. To use your own custom image (such as one you build using our [Custom Slurm Image Generation](https://github.com/crusoecloud/solutions-library/tree/main/slurm-custom-image)), ensure that you enable custom image in `terraform.tfvars` and provide the name of the custom image in your Crusoe Cloud account:
+
+```
+# terraform.tfvars file
+... # other configurations
+
+enable_custom_images = true
+custom_image_name = "your-custom-slurm-image:tag"
+
+```
+
+This will override the default setting and use custom images for the nodes.
+
 ## User Management
 To add additional users to your cluster, configure the `slurm_users` variable in your
 `terraform.tfvars` file and run `terraform apply`. The following example adds three

--- a/examples/custom-images.tfvars
+++ b/examples/custom-images.tfvars
@@ -1,0 +1,20 @@
+# common configuration
+location = "us-east1-a"
+project_id = "ad337f40-ac0f-4165-be89-d4e0d03c699f"
+ssh_public_key_path = "~/.ssh/id_ed25519.pub"
+vpc_subnet_id = "0538aecf-e3d7-484c-aa3f-bee399b344d8"
+
+# slurm-compute-node configuration
+slurm_compute_node_type = "h100-80gb-sxm-ib.8x"
+slurm_compute_node_ib_partition_id = "686331f9-9368-4245-bf48-a359a8c0e476"
+slurm_compute_node_count = 1
+
+# slurm users configuration
+slurm_users = [{
+  name = "user1"
+  uid = 1001
+  ssh_pubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPLZWkpxGIeCLrEsZQVbbeoQdT7fZuW84eTjRMy0zgPr yjeong@crusoe.ai"
+}]
+
+enable_custom_images = true
+custom_image_name = "slurm-new:latest"

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "crusoe_compute_instance" "slurm_head_node" {
   ssh_key    = local.ssh_public_key
   location   = var.location
   project_id = var.project_id
-  image    = "ubuntu22.04-nvidia-slurm:12.4"
+  image    = "ubuntu22.04-nvidia-slurm:latest"
   reservation_id = var.slurm_head_node_reservation_id
   host_channel_adapters = var.slurm_head_node_ib_partition_id != null ? [{
     ib_partition_id = var.slurm_head_node_ib_partition_id
@@ -41,7 +41,7 @@ resource "crusoe_compute_instance" "slurm_login_node" {
   ssh_key    = local.ssh_public_key
   location   = var.location
   project_id = var.project_id
-  image    = "ubuntu22.04-nvidia-slurm:12.4"
+  image    = "ubuntu22.04-nvidia-slurm:latest"
   reservation_id = var.slurm_login_node_reservation_id
   host_channel_adapters = var.slurm_login_node_ib_partition_id != null ? [{
     ib_partition_id = var.slurm_login_node_ib_partition_id
@@ -98,7 +98,7 @@ resource "crusoe_compute_instance" "slurm_compute_node" {
   ssh_key  = local.ssh_public_key
   location = var.location
   project_id = var.project_id
-  image    = "ubuntu22.04-nvidia-slurm:12.4"
+  image    = "ubuntu22.04-nvidia-slurm:latest"
   reservation_id = var.slurm_compute_node_reservation_id
   host_channel_adapters = var.slurm_compute_node_ib_partition_id != null ? [{
     ib_partition_id = var.slurm_compute_node_ib_partition_id

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,8 @@ resource "crusoe_compute_instance" "slurm_head_node" {
   ssh_key    = local.ssh_public_key
   location   = var.location
   project_id = var.project_id
-  image    = "ubuntu22.04-nvidia-slurm:latest"
+  image    = !var.enable_custom_images ? "ubuntu22.04-nvidia-slurm:latest" : null
+  custom_image = var.enable_custom_images ? var.custom_image_name : null
   reservation_id = var.slurm_head_node_reservation_id
   host_channel_adapters = var.slurm_head_node_ib_partition_id != null ? [{
     ib_partition_id = var.slurm_head_node_ib_partition_id
@@ -41,7 +42,8 @@ resource "crusoe_compute_instance" "slurm_login_node" {
   ssh_key    = local.ssh_public_key
   location   = var.location
   project_id = var.project_id
-  image    = "ubuntu22.04-nvidia-slurm:latest"
+  image    = !var.enable_custom_images ? "ubuntu22.04-nvidia-slurm:latest" : null
+  custom_image = var.enable_custom_images ? var.custom_image_name : null
   reservation_id = var.slurm_login_node_reservation_id
   host_channel_adapters = var.slurm_login_node_ib_partition_id != null ? [{
     ib_partition_id = var.slurm_login_node_ib_partition_id
@@ -98,7 +100,8 @@ resource "crusoe_compute_instance" "slurm_compute_node" {
   ssh_key  = local.ssh_public_key
   location = var.location
   project_id = var.project_id
-  image    = "ubuntu22.04-nvidia-slurm:latest"
+  image    = !var.enable_custom_images ? "ubuntu22.04-nvidia-slurm:latest" : null
+  custom_image = var.enable_custom_images ? var.custom_image_name : null
   reservation_id = var.slurm_compute_node_reservation_id
   host_channel_adapters = var.slurm_compute_node_ib_partition_id != null ? [{
     ib_partition_id = var.slurm_compute_node_ib_partition_id

--- a/variables.tf
+++ b/variables.tf
@@ -72,7 +72,7 @@ variable "slurm_login_node_ib_partition_id" {
 variable "slurm_nfs_node_type" {
   description = "The slurm nfs node instance type."
   type        = string
-  default     = "s1a.80x"
+  default     = "c1a.64x"
 }
 
 variable "slurm_nfs_home_size" {
@@ -173,4 +173,16 @@ variable "grafana_admin_password" {
   type        = string
   default     = "admin"
   sensitive   = true
+}
+
+variable "enable_custom_images" {
+  description = "Enable custom images instead of curated slurm image"
+  type        = bool
+  default     = false
+}
+
+variable "custom_image_name" {
+  description = "Name of the custom image - only provide it when you enable custom images"
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
Customers who build custom images are now able to enable the usage of those images in building the slurm cluster in lieu of curated images.